### PR TITLE
Add full support for cache-aware roofline profiling (including plotting code segments as points)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A tool for analysing performance analysis results returned e.g. by Adaptyst.
 
 ## Disclaimer
-This is currently a dev version and the tool is under active development. Bugs are to be expected (with the test coverage to be expanded soon). Use at your own risk!
+This is currently a dev version and the tool is under active development. The tests are limited at the moment and bugs are to be expected. Use at your own risk!
 
 All feedback is welcome.
 

--- a/src/adaptystanalyser/results.py
+++ b/src/adaptystanalyser/results.py
@@ -212,6 +212,8 @@ class ProfilingResults:
             }
         }
 
+        self._roofline_info = {}
+
         if metrics_path.exists():
             with metrics_path.open(mode='r') as f:
                 for line in f:
@@ -220,6 +222,27 @@ class ProfilingResults:
                         'title': match.group(2),
                         'flame_graph': True
                     }
+
+                    carm_match = re.search(r'^CARM_(\S+)$', match.group(2))
+                    if carm_match is not None:
+                        # Assuming Intel-x86-like for now, TODO: CPU type
+                        # detection in AdaptivePerf
+                        self._roofline_info = {
+                            'cpu_type': 'Intel_x86',
+                            'ai_keys': [
+                                'mem_inst_retired.any'
+                            ],
+                            'instr_keys': [
+                                'fp_arith_inst_retired.scalar_single',
+                                'fp_arith_inst_retired.scalar_double',
+                                'fp_arith_inst_retired.128b_packed_single',
+                                'fp_arith_inst_retired.128b_packed_double',
+                                'fp_arith_inst_retired.256b_packed_single',
+                                'fp_arith_inst_retired.256b_packed_double',
+                                'fp_arith_inst_retired.512b_packed_single',
+                                'fp_arith_inst_retired.512b_packed_double'
+                            ]
+                        }
 
         self._general_metrics = {}
 
@@ -602,6 +625,12 @@ class ProfilingResults:
         * "children": the list of all threads/processes spawned by the
           thread/process. Each element has the same structure as the root
           except for "general_metrics" which is absent.
+        * "roofline": the JSON object with information necessary for
+          interpreting roofline profiling results. The structure is as follows:
+          {"cpu_type": "<CPU type, e.g. Intel_x86>", "ai_keys": [<events for
+          calculating arithmetic intensity>], "instr_keys": [<events for
+          calculating FLOPS etc.>]}. This is set only for the root and
+          it can be empty.
         """
         def to_ms(num):
             return None if num is None else num / 1000000
@@ -646,6 +675,7 @@ class ProfilingResults:
                 to_return['general_metrics'] = self._general_metrics
                 to_return['src'] = self._sources
                 to_return['src_index'] = self._source_index
+                to_return['roofline'] = self._roofline_info
 
             children = tree.children(node.identifier)
 

--- a/src/adaptystanalyser/results.py
+++ b/src/adaptystanalyser/results.py
@@ -223,26 +223,46 @@ class ProfilingResults:
                         'flame_graph': True
                     }
 
-                    carm_match = re.search(r'^CARM_(\S+)$', match.group(2))
-                    if carm_match is not None:
-                        # Assuming Intel-x86-like for now, TODO: CPU type
-                        # detection in AdaptivePerf
-                        self._roofline_info = {
-                            'cpu_type': 'Intel_x86',
-                            'ai_keys': [
-                                'mem_inst_retired.any'
-                            ],
-                            'instr_keys': [
-                                'fp_arith_inst_retired.scalar_single',
-                                'fp_arith_inst_retired.scalar_double',
-                                'fp_arith_inst_retired.128b_packed_single',
-                                'fp_arith_inst_retired.128b_packed_double',
-                                'fp_arith_inst_retired.256b_packed_single',
-                                'fp_arith_inst_retired.256b_packed_double',
-                                'fp_arith_inst_retired.512b_packed_single',
-                                'fp_arith_inst_retired.512b_packed_double'
-                            ]
-                        }
+                    if len(self._roofline_info) == 0:
+                        carm_match = re.search(r'^CARM_(\S+)_(\S+)$', match.group(2))
+                        if carm_match is not None:
+                            cpu_type = carm_match.group(1)
+
+                            if cpu_type == 'INTEL':
+                                self._roofline_info = {
+                                    'cpu_type': 'Intel_x86',
+                                    'ai_keys': [
+                                        'mem_inst_retired.any'
+                                    ],
+                                    'instr_keys': [
+                                        'fp_arith_inst_retired.scalar_single',
+                                        'fp_arith_inst_retired.scalar_double',
+                                        'fp_arith_inst_retired.128b_packed_single',
+                                        'fp_arith_inst_retired.128b_packed_double',
+                                        'fp_arith_inst_retired.256b_packed_single',
+                                        'fp_arith_inst_retired.256b_packed_double',
+                                        'fp_arith_inst_retired.512b_packed_single',
+                                        'fp_arith_inst_retired.512b_packed_double'
+                                    ]
+                                }
+                            elif cpu_type == 'AMD':
+                                self._roofline_info = {
+                                    'cpu_type': 'AMD_x86',
+                                    'ai_keys': [
+                                        'ls_dispatch:ld_dispatch',
+                                        'ls_dispatch:store_dispatch'
+                                    ],
+                                    'instr_keys': [
+                                        'retired_sse_avx_operations:sp_mult_add_flops',
+                                        'retired_sse_avx_operations:dp_mult_add_flops',
+                                        'retired_sse_avx_operations:sp_add_sub_flops',
+                                        'retired_sse_avx_operations:dp_add_sub_flops',
+                                        'retired_sse_avx_operations:sp_mult_flops',
+                                        'retired_sse_avx_operations:dp_mult_flops',
+                                        'retired_sse_avx_operations:sp_div_flops',
+                                        'retired_sse_avx_operations:dp_div_flops'
+                                    ]
+                                }
 
         self._general_metrics = {}
 

--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -1738,6 +1738,21 @@ function onAddToRooflineClick(event) {
         // arith_intensity = flop / (ai_nodes[0] * (
         //     4 * single_scalar_ratio + 8 * double_scalar_ratio +
         //         16 * sse_ratio + 32 * avx2_ratio + 64 * avx512_ratio))
+    } else if (info.cpu_type === 'AMD_x86') {
+        flop = instr_nodes[0] + instr_nodes[1] + instr_nodes[2] +
+            instr_nodes[3] + instr_nodes[4] + instr_nodes[5] +
+            instr_nodes[6] + instr_nodes[7];
+        flops = flop / (walltime_node[0][0].value / 1000000000);
+
+        var single_ratio =
+            (instr_nodes[0] + instr_nodes[2] +
+             instr_nodes[4] + instr_nodes[6]) / instr_sum;
+        var double_ratio =
+            (instr_nodes[1] + instr_nodes[3] +
+             instr_nodes[5] + instr_nodes[7]) / instr_sum;
+        arith_intensity = flop / ((ai_nodes[0] + ai_nodes[1]) *
+                                  (4 * single_ratio +
+                                   8 * double_ratio));
     }
 
     session.roofline_dict[name] = [arith_intensity, flops];

--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -1266,9 +1266,9 @@ function updateRoofline(window_obj, roofline_obj) {
 
         roofline_obj.plot_config.data = plot_data;
         roofline_obj.plot_config.xAxis.domain =
-            [0, turning_x > max_point_x ? 1.5 * turning_x : 1.1 * max_point_x];
+            [0.00390625, turning_x > max_point_x ? 1.5 * turning_x : 1.1 * max_point_x];
         roofline_obj.plot_config.yAxis.domain =
-            [0, model.fp_fma.gflops > max_point_y ?
+            [0.00390625, model.fp_fma.gflops > max_point_y ?
              1.25 * model.fp_fma.gflops : 1.1 * max_point_y];
         functionPlot(roofline_obj.plot_config);
     }
@@ -1393,11 +1393,13 @@ function onRooflineTypeChange(event, window_id) {
         width: container.width() - 10,
         height: container.height() - 10,
         xAxis: {
+            type: 'log',
             domain: [0.00390625, turning_x > max_point_x ?
                      1.5 * turning_x : 1.1 * max_point_x]
         },
         yAxis: {
-            domain: [0, model.fp_fma.gflops > max_point_y ?
+            type: 'log',
+            domain: [0.00390625, model.fp_fma.gflops > max_point_y ?
                      1.25 * model.fp_fma.gflops :
                      1.1 * max_point_y]
         },

--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -826,9 +826,13 @@ function setupWindow(window_obj, type, data) {
         }
 
         var dict = session.metrics_dict[data.timeline_group_id];
+        var show_carm_checked = $('#show_carm').prop('checked');
         for (const [k, v] of Object.entries(dict)) {
-            window_obj.find('.flamegraph_metric').append(
-                new Option(v.title, k));
+            if (show_carm_checked ||
+                !v.title.startsWith('CARM_')) {
+                window_obj.find('.flamegraph_metric').append(
+                    new Option(v.title, k));
+            }
         }
 
         window_obj.find('.flamegraph_metric').val('walltime');

--- a/src/adaptystanalyser/templates/viewer.html
+++ b/src/adaptystanalyser/templates/viewer.html
@@ -546,10 +546,15 @@
                        onkeyup="checkValidPercentage(event)"
                        onfocusout="insertValidPercentage(this)" />
       </div>
-      <div>
+      <div class="margin_bottom">
         <input type="checkbox" id="always_ms"
                name="always_ms" onchange="">
         <label for="always_ms">Always display runtimes in milliseconds</label>
+      </div>
+      <div>
+        <input type="checkbox" id="show_carm"
+               name="show_carm" onchange="">
+        <label for="show_carm">Display roofline-related flame graphs (with the title starting with CARM_)</label>
       </div>
     </div>
     <div id="thread_menu_block" class="menu_block">

--- a/src/adaptystanalyser/templates/viewer.html
+++ b/src/adaptystanalyser/templates/viewer.html
@@ -137,6 +137,11 @@
           cursor:default;
       }
 
+      .menu_item_first {
+          padding:5px;
+          cursor:default;
+      }
+
       #callchain_item {
           border-top-color:black;
           border-top-width:4px;
@@ -149,7 +154,7 @@
           color:gray;
       }
 
-      .menu_item:hover {
+      .menu_item:hover, .menu_item_first:hover {
           background-color:#DDDDDD;
       }
 
@@ -236,8 +241,8 @@
       .roofline_window {
           min-width:750px;
           width:750px;
-          min-height:550px;
-          height:550px;
+          min-height:750px;
+          height:750px;
       }
 
       .window {
@@ -357,9 +362,10 @@
           min-width:200px;
           flex-direction:column;
           margin-right:10px;
+          overflow:hidden;
       }
 
-      .roofline_type, .roofline_bounds {
+      .roofline_type, .roofline_bounds, .roofline_points {
           margin-bottom:5px;
       }
 
@@ -367,8 +373,28 @@
           width:100%;
       }
 
+      .roofline_point_select_div {
+          display:flex;
+          flex-direction:row;
+          margin-bottom:10px;
+      }
+
+      .roofline_point_select {
+          flex-grow:1;
+          min-width:0;
+          margin-right:5px;
+      }
+
+      .roofline_point_delete {
+          cursor:pointer;
+      }
+
       .roofline_details {
           flex-grow:1;
+      }
+
+      .roofline_details_text {
+          margin-bottom:10px;
       }
 
       .roofline {

--- a/src/adaptystanalyser/templates/viewer.html
+++ b/src/adaptystanalyser/templates/viewer.html
@@ -239,8 +239,8 @@
       }
 
       .roofline_window {
-          min-width:750px;
-          width:750px;
+          min-width:800px;
+          width:800px;
           min-height:750px;
           height:750px;
       }
@@ -358,8 +358,8 @@
 
       .roofline_settings {
           display:flex;
-          width:200px;
-          min-width:200px;
+          width:250px;
+          min-width:250px;
           flex-direction:column;
           margin-right:10px;
           overflow:hidden;


### PR DESCRIPTION
This PR, along with [the Adaptyst one](https://github.com/Adaptyst/Adaptyst/pull/57), adds full support for cache-aware roofline profiling through [the CARM Tool](https://github.com/champ-hub/carm-roofline). This includes plotting code segments from a flame graph as points on a roofline plot.

Analysing roofline data from AMD CPUs is currently marked as very experimental since appropriate AMD-based machines for testing will become available to us only in the next few days/weeks.