### PR TITLE
Fix regex replacement change not working in flame graphs

### DIFF
--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -2137,8 +2137,8 @@ function onReplacementClick(info) {
         return;
     }
 
-    window_dict[window_id].data.replacements[query] = replacement;
-    window_dict[window_id].data.flamegraph_obj.update();
+    window_dict[data.window_id].data.replacements[query] = replacement;
+    window_dict[data.window_id].data.flamegraph_obj.update();
 }
 
 function onMetricChange(window_id, event) {


### PR DESCRIPTION
This PR fixes the bug causing flame graph regex replacement updates not working in any case other than deleting.