### PR TITLE
Fix bugs as of 15/04/2025

### DIFF
--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -831,8 +831,10 @@ function setupWindow(window_obj, type, data) {
     loading_jquery.prependTo(window_obj.find('.window_content'));
     loading_jquery.show();
 
-    window_obj.appendTo('body');
-    changeFocus(window_obj.attr('id'));
+    if (!existing_window) {
+        window_obj.appendTo('body');
+        changeFocus(window_obj.attr('id'));
+    }
 
     window_dict[window_id].setup_data = data;
 

--- a/src/adaptystanalyser/static/viewer.js
+++ b/src/adaptystanalyser/static/viewer.js
@@ -920,7 +920,7 @@ function setupWindow(window_obj, type, data) {
             var pid_tid = data.timeline_group_id.split('_');
 
             $.ajax({
-                url: $('#block').attr('result_id') + '/',
+                url: window_dict[window_id].session + '/',
                 method: 'POST',
                 dataType: 'json',
                 data: {pid: pid_tid[0], tid: pid_tid[1],
@@ -990,7 +990,7 @@ function setupWindow(window_obj, type, data) {
             loading_jquery.hide();
         } else {
             $.ajax({
-                url: $('#block').attr('result_id') + '/',
+                url: window_dict[window_id].session + '/',
                 method: 'POST',
                 dataType: 'json',
                 data: {general_analysis: type}


### PR DESCRIPTION
This PR fixes the following bugs:
* ```appendTo()``` and ```changeFocus()``` are unnecessarily and incorrectly called when a window is refreshed
* Data retrieval fails when a window from a different session than the current one is refreshed in some cases