### PR TITLE
Move off-CPU timeline sampling feature to client side and change versioning scheme

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,25 +29,27 @@ docker-build:
     entrypoint: [""]
   stage: build
   script:
-    - |
-      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        export IMAGE_DESTINATION=gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:latest
-      else
-        export IMAGE_DESTINATION=gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:$CI_COMMIT_BRANCH
-      fi
     # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
     # Build and push the image from the Dockerfile at the root of the project.
-    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION
+    - |
+      if [[ "$CI_COMMIT_TAG" != "" ]]; then
+        IMAGE_DESTINATION=gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:latest
+        IMAGE_DESTINATION_NAMED=gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:$CI_COMMIT_TAG
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_NAMED
+      else
+        IMAGE_DESTINATION=gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:branch-$CI_COMMIT_BRANCH
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION
+      fi
     # Print the full registry path of the pushed image
     - echo "Image pushed successfully to ${IMAGE_DESTINATION}"
 
 docker-test:
   image:
-    name: gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:$CI_COMMIT_BRANCH
+    name: gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:branch-$CI_COMMIT_BRANCH
     entrypoint: [""]
   rules:
-    - if: $CI_COMMIT_BRANCH != "main"
+    - if: $CI_COMMIT_TAG == null
   stage: test
   script:
     - cd $CI_PROJECT_DIR
@@ -58,7 +60,7 @@ docker-test-main:
     name: gitlab-registry.cern.ch/adaptyst/adaptyst-analyser:latest
     entrypoint: [""]
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_TAG != null
   stage: test
   script:
     - cd $CI_PROJECT_DIR
@@ -68,7 +70,7 @@ syclops-pviewer-deploy:
   # Based on https://paas.docs.cern.ch/2._Deploy_Applications/Deploy_Docker_Image/2-automatic-redeployments/#integrate-redeployment-in-ci-workflow
   stage: deploy
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_TAG != null
   image: gitlab-registry.cern.ch/paas-tools/openshift-client:latest
   variables:
     SERVER: https://api.paas.okd.cern.ch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,9 +4,8 @@
 
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
-      when: never
-    - when: always
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_TAG != null
 
 # Most of the content below is based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
 stages:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Adaptyst Analyser
 [![License: GNU GPL v3](https://img.shields.io/badge/license-GNU%20GPL%20v3-blue)]()
-[![Version: 0.1.dev](https://img.shields.io/badge/version-0.1.dev-red)]()
+[![Version](https://img.shields.io/github/v/release/adaptyst/adaptyst-analyser?include_prereleases&label=version)](https://github.com/Adaptyst/adaptyst-analyser/releases)
 
 A tool for analysing performance analysis results returned e.g. by Adaptyst.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -13,7 +13,7 @@ authors = [
   { name="Maksymilian Graczyk", email="maksymilian.graczyk@cern.ch" },
 ]
 description = "A tool for analysing performance analysis results returned e.g. by Adaptyst"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
   "Jinja2",
   "treelib",
@@ -31,7 +31,11 @@ classifiers = [
 adaptyst-analyser = "adaptystanalyser.cli:main"
 
 [tool.hatch.version]
-source = "vcs"
+source = "versioningit"
+
+[tool.versioningit.format]
+distance = "{base_version}+{distance}.{rev}"
+distance-dirty = "{base_version}+{distance}.{rev}.d{build_date:%Y%m%d}"
 
 [tool.hatch.build.targets.wheel]
 only-include = ["src/adaptystanalyser"]

--- a/src/adaptystanalyser/app.py
+++ b/src/adaptystanalyser/app.py
@@ -126,7 +126,7 @@ def main():
         ids=ProfilingResults.get_all_ids(
             app.config['PROFILING_STORAGE']),
         offcpu_sampling=app.config.get(
-            'OFFCPU_SAMPLING', 0),
+            'OFFCPU_SAMPLING', 1),
         scripts=scripts,
         stylesheets=stylesheets,
         d3_flamegraph_css=d3_flamegraph_css.replace('\n', ' '))

--- a/src/adaptystanalyser/cli.py
+++ b/src/adaptystanalyser/cli.py
@@ -24,17 +24,28 @@ def main():
                         'default: 127.0.0.1:8000',
                         default='127.0.0.1:8000')
     parser.add_argument('-o',
-                        metavar='PERIOD',
+                        metavar='INT FROM 0 TO 100',
                         dest='off_cpu_sampling',
-                        help='sampling period in ms for rendering captured '
-                        'off-CPU regions in the timeline view (sampling is '
-                        'done in a similar way as off-CPU sampling is in '
-                        'Adaptyst, 0 disables sampling and makes the '
-                        'website display all captured off-CPU regions), '
-                        'default: 0',
-                        default=0)
+                        type=int,
+                        help='default off-CPU timeline display scale for '
+                        'users (the value is an integer between 0 '
+                        'and 100 inclusive converted to the scale between '
+                        '0.0 and 1.0, where 0.0 means "do not display '
+                        'any off-CPU periods on the timeline", 1.0 means '
+                        '"display all off-CPU periods on the timeline", '
+                        'and anything in-between means "sample off-CPU '
+                        'periods on the timeline in a similar way Adaptyst '
+                        'does during profiling, with the sampling frequency '
+                        'being higher with higher values") (default: 100)',
+                        default=100)
 
     args = parser.parse_args()
+
+    if args.off_cpu_sampling < 0 or \
+       args.off_cpu_sampling > 100:
+        print('adaptyst-analyser: error: -o must specify an integer '
+              'between 0 and 100 inclusive', file=sys.stderr)
+        return 1
 
     result_path = Path(args.results)
 
@@ -52,7 +63,7 @@ def main():
     env = os.environ.copy()
     env.update({
         'FLASK_PROFILING_STORAGE': str(result_path),
-        'FLASK_OFFCPU_SAMPLING': str(args.off_cpu_sampling)
+        'FLASK_OFFCPU_SAMPLING': str(args.off_cpu_sampling / 100)
     })
 
     try:

--- a/src/adaptystanalyser/cli.py
+++ b/src/adaptystanalyser/cli.py
@@ -8,6 +8,7 @@ import sys
 import subprocess
 import os
 from pathlib import Path
+from importlib.metadata import version
 
 
 def main():
@@ -17,6 +18,9 @@ def main():
     parser.add_argument('results', metavar='PATH',
                         help='path to a profiling results directory '
                         '(relative or absolute)')
+    parser.add_argument('--version', action='version', help='print '
+                        'version and exit', version='v' + version(
+                            'adaptyst-analyser'))
     parser.add_argument('-a',
                         metavar='ADDR',
                         dest='address',

--- a/src/adaptystanalyser/templates/viewer.html
+++ b/src/adaptystanalyser/templates/viewer.html
@@ -122,6 +122,19 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           align-items:center;
       }
 
+      .setting_item {
+          display:flex;
+          align-items:center;
+      }
+
+      .setting_label_left {
+          margin-right:5px;
+      }
+
+      .setting_label_right {
+          margin-left:5px;
+      }
+
       #runtime {
           flex-grow:1;
       }
@@ -560,8 +573,8 @@ Adaptyst Analyser: a tool for analysing performance analysis results
       </div>
     </div>
     <div id="settings_block">
-      <div class="margin_bottom">
-        <label for="off_cpu_scale" id="off_cpu_scale_desc">
+      <div class="margin_bottom setting_item">
+        <label for="off_cpu_scale" id="off_cpu_scale_desc" class="setting_label_left">
           Off-CPU timeline display scale:
         </label>
         <input name="off_cpu_scale"
@@ -571,8 +584,8 @@ Adaptyst Analyser: a tool for analysing performance analysis results
                step=".01"
                value="{{ offcpu_sampling }}" />
       </div>
-      <div class="margin_bottom">
-        <label for="threshold_input">
+      <div class="margin_bottom setting_item">
+        <label for="threshold_input" class="setting_label_left">
           Do not display flame graph blocks taking less than this % of samples:
         </label>
         <input type="number" name="threshold_input"
@@ -581,8 +594,8 @@ Adaptyst Analyser: a tool for analysing performance analysis results
                onkeyup="checkValidPercentage(event)"
                onfocusout="insertValidPercentage(this)" />
       </div>
-      <div class="margin_bottom">
-        <label for="runtime_diff_threshold_input">
+      <div class="margin_bottom setting_item">
+        <label for="runtime_diff_threshold_input" class="setting_label_left">
           Warn if the difference between exact and sampled runtime exceeds this %:
         </label>
         <input type="number" value="50", step="1" min="0"
@@ -591,15 +604,15 @@ Adaptyst Analyser: a tool for analysing performance analysis results
                onkeyup="checkValidPercentage(event)"
                onfocusout="insertValidPercentage(this)" />
       </div>
-      <div class="margin_bottom">
+      <div class="margin_bottom setting_item">
         <input type="checkbox" id="always_ms"
                name="always_ms" onchange="">
-        <label for="always_ms">Always display runtimes in milliseconds</label>
+        <label for="always_ms" class="setting_label_right">Always display runtimes in milliseconds</label>
       </div>
-      <div>
+      <div class="setting_item">
         <input type="checkbox" id="show_carm"
                name="show_carm" onchange="">
-        <label for="show_carm">Display roofline-related flame graphs (with the title starting with CARM_)</label>
+        <label for="show_carm" class="setting_label_right">Display roofline-related flame graphs (with the title starting with CARM_)</label>
       </div>
     </div>
     <div id="thread_menu_block" class="menu_block">

--- a/src/adaptystanalyser/templates/viewer.html
+++ b/src/adaptystanalyser/templates/viewer.html
@@ -23,7 +23,6 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           href="{{ url_for('static', filename=stylesheet) }}" />
     {% endfor %}
     <script type="text/javascript" id="viewer_script"
-            data-offcpu-sampling="{{ offcpu_sampling }}"
             data-d3-flamegraph-css="{{ d3_flamegraph_css }}"
             src="{{ url_for('static', filename='viewer.js') }}"></script>
     <style type="text/css">
@@ -202,6 +201,10 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           cursor:pointer;
       }
 
+      #refresh_needed {
+          display:none;
+      }
+
       .flamegraph_metric {
           max-width:250px;
           margin-right:5px;
@@ -212,10 +215,6 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           text-align:center;
           margin-left:5px;
           margin-right:5px;
-      }
-
-      #settings {
-          display:none;
       }
 
       #threshold_input, #runtime_diff_threshold_input {
@@ -331,7 +330,8 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           padding:10px;
       }
 
-      #glossary {
+      #glossary, #off_cpu_sampling_warning, #no_off_cpu_warning {
+          display:none;
           margin-top:10px;
           font-style:italic;
       }
@@ -486,6 +486,11 @@ Adaptyst Analyser: a tool for analysing performance analysis results
       .code_copy_all {
           min-width:24px;
       }
+
+      .disabled {
+          fill:rgba(0, 0, 0, 0.5);
+          cursor:not-allowed;
+      }
     </style>
   </head>
   <body onclick="closeAllMenus(event)">
@@ -503,24 +508,29 @@ Adaptyst Analyser: a tool for analysing performance analysis results
           <option value="{{ x.value }}" data-label="{{ x.label }}">{{ x }}</option>
           {% endfor %}
         </select>
-        <div id="loading">
-          <img src="{{ url_for('static', filename='loading.svg') }}"
-               alt="Please wait..." title="Please wait..." />
-        </div>
         <div id="settings">
-          <!-- The two SVGs below are from Google Material Icons, originally
+          <!-- The three SVGs below are from Google Material Icons, originally
                licensed under Apache License 2.0:
                https://www.apache.org/licenses/LICENSE-2.0.txt
                (covered by GNU GPL v3 here) -->
-          <svg xmlns="http://www.w3.org/2000/svg" height="32px"
+          <svg id="settings_settings"
+               xmlns="http://www.w3.org/2000/svg" height="32px"
                viewBox="0 -960 960 960" width="32px" fill="#000000"
                onclick="onSettingsClick(event)" class="pointer">
             <title>Settings</title>
             <path d="m388-80-20-126q-19-7-40-19t-37-25l-118 54-93-164 108-79q-2-9-2.5-20.5T185-480q0-9 .5-20.5T188-521L80-600l93-164 118 54q16-13 37-25t40-18l20-127h184l20 126q19 7 40.5 18.5T669-710l118-54 93 164-108 77q2 10 2.5 21.5t.5 21.5q0 10-.5 21t-2.5 21l108 78-93 164-118-54q-16 13-36.5 25.5T592-206L572-80H388Zm48-60h88l14-112q33-8 62.5-25t53.5-41l106 46 40-72-94-69q4-17 6.5-33.5T715-480q0-17-2-33.5t-7-33.5l94-69-40-72-106 46q-23-26-52-43.5T538-708l-14-112h-88l-14 112q-34 7-63.5 24T306-642l-106-46-40 72 94 69q-4 17-6.5 33.5T245-480q0 17 2.5 33.5T254-413l-94 69 40 72 106-46q24 24 53.5 41t62.5 25l14 112Zm44-210q54 0 92-38t38-92q0-54-38-92t-92-38q-54 0-92 38t-38 92q0 54 38 92t92 38Zm0-130Z"/>
           </svg>
-          <svg xmlns="http://www.w3.org/2000/svg" height="32px"
+          <svg id="refresh"
+               xmlns="http://www.w3.org/2000/svg" height="32px"
+               viewBox="0 -960 960 960" width="32px"
+               onclick="" class="disabled">
+            <title>Refresh the session (including the timeline)</title>
+            <path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/>
+          </svg>
+          <svg id="general_analyses" xmlns="http://www.w3.org/2000/svg"
+               height="32px"
                viewBox="0 -960 960 960" width="32px" fill="#000000"
-               onclick="onGeneralAnalysesClick(event)" class="pointer">
+               onclick="" class="disabled">
             <title>General analyses</title>
             <path d="M282.67-278h66.66v-203.33h-66.66V-278Zm328 0h66.66v-413.33h-66.66V-278Zm-164 0h66.66v-118.67h-66.66V-278Zm0-203.33h66.66V-548h-66.66v66.67ZM186.67-120q-27 0-46.84-19.83Q120-159.67 120-186.67v-586.66q0-27 19.83-46.84Q159.67-840 186.67-840h586.66q27 0 46.84 19.83Q840-800.33 840-773.33v586.66q0 27-19.83 46.84Q800.33-120 773.33-120H186.67Zm0-66.67h586.66v-586.66H186.67v586.66Zm0-586.66v586.66-586.66Z"/>
           </svg>
@@ -529,6 +539,20 @@ Adaptyst Analyser: a tool for analysing performance analysis results
             <b><font color="#0294e3">blue parts</font></b> are off-CPU. <b>Right-click</b>
             any thread/process to open the details menu.
           </div>
+          <div id="off_cpu_sampling_warning">
+            <b><font color="#ff0000">WARNING:</font></b> The current off-CPU timeline
+            display scale is <span id="off_cpu_scale_value"></span>, which means that <b>the timeline does
+              not show off-CPU periods missing the sampling period of <span id="off_cpu_sampling_period"></span> ms!</b> <b><u>No</u></b> other analyses are affected.
+          </div>
+          <div id="no_off_cpu_warning">
+            <b><font color="#ff0000">WARNING:</font></b> The current off-CPU timeline
+            display scale is 0, which means that <b>the timeline does
+              not show any off-CPU periods!</b> <b><u>No</u></b> other analyses are affected.
+          </div>
+        </div>
+        <div id="loading">
+          <img src="{{ url_for('static', filename='loading.svg') }}"
+               alt="Please wait..." title="Please wait..." />
         </div>
       </div>
       <div id="block" class="scrollable">
@@ -537,18 +561,35 @@ Adaptyst Analyser: a tool for analysing performance analysis results
     </div>
     <div id="settings_block">
       <div class="margin_bottom">
-        Do not display flame graph blocks taking less than
-        this % of samples: <input type="number" value="2.50" min="0" max="100"
-                                  step=".1" id="threshold_input"
-                                  onkeyup="checkValidPercentage(event)"
-                                  onfocusout="insertValidPercentage(this)" />
+        <label for="off_cpu_scale" id="off_cpu_scale_desc">
+          Off-CPU timeline display scale:
+        </label>
+        <input name="off_cpu_scale"
+               id="off_cpu_scale"
+               type="range"
+               min="0" max="1"
+               step=".01"
+               value="{{ offcpu_sampling }}" />
       </div>
       <div class="margin_bottom">
-        Warn if the difference between exact and sampled runtime exceeds
-        this %: <input type="number" value="50", step="1" min="0"
-                       id="runtime_diff_threshold_input"
-                       onkeyup="checkValidPercentage(event)"
-                       onfocusout="insertValidPercentage(this)" />
+        <label for="threshold_input">
+          Do not display flame graph blocks taking less than this % of samples:
+        </label>
+        <input type="number" name="threshold_input"
+               value="2.50" min="0" max="100"
+               step=".1" id="threshold_input"
+               onkeyup="checkValidPercentage(event)"
+               onfocusout="insertValidPercentage(this)" />
+      </div>
+      <div class="margin_bottom">
+        <label for="runtime_diff_threshold_input">
+          Warn if the difference between exact and sampled runtime exceeds this %:
+        </label>
+        <input type="number" value="50", step="1" min="0"
+               name="runtime_diff_threshold_input"
+               id="runtime_diff_threshold_input"
+               onkeyup="checkValidPercentage(event)"
+               onfocusout="insertValidPercentage(this)" />
       </div>
       <div class="margin_bottom">
         <input type="checkbox" id="always_ms"


### PR DESCRIPTION
This PR moves the off-CPU timeline sampling feature to the client side so that rendering optimisations can be adjusted per session rather than per entire server instance as it is now. Additionally, the versioning scheme is updated to be more in line with the new Adaptyst versioning scheme, taking into account the Python rules for version names.

The pipeline is expected to fail before the first tag is created (this will happen after merging).